### PR TITLE
Fix cpu info management

### DIFF
--- a/linux/stat.go
+++ b/linux/stat.go
@@ -62,7 +62,7 @@ func ReadStat(path string) (*Stat, error) {
 		if len(fields) == 0 {
 			continue
 		}
-		if fields[0] == "cpu" {
+		if fields[0][:3] == "cpu" {
 			if cpuStat := createCPUStat(fields); cpuStat != nil {
 				if i == 0 {
 					stat.CPUStatAll = *cpuStat


### PR DESCRIPTION
Looking for the exact "CPU" string in the field, it will only ever trigger in the block with the first line.
Using slice will do what I believe was the intended behavior
