### PR TITLE
prevent index out of range error

### DIFF
--- a/linux/stat.go
+++ b/linux/stat.go
@@ -35,17 +35,31 @@ type CPUStat struct {
 func createCPUStat(fields []string) *CPUStat {
 	s := CPUStat{}
 	s.Id = fields[0]
-	s.User, _ = strconv.ParseUint(fields[1], 10, 64)
-	s.Nice, _ = strconv.ParseUint(fields[2], 10, 64)
-	s.System, _ = strconv.ParseUint(fields[3], 10, 64)
-	s.Idle, _ = strconv.ParseUint(fields[4], 10, 64)
-	s.IOWait, _ = strconv.ParseUint(fields[5], 10, 64)
-	s.IRQ, _ = strconv.ParseUint(fields[6], 10, 64)
-	s.SoftIRQ, _ = strconv.ParseUint(fields[7], 10, 64)
-	s.Steal, _ = strconv.ParseUint(fields[8], 10, 64)
-	s.Guest, _ = strconv.ParseUint(fields[9], 10, 64)
-	if len(fields) > 10 {
-		s.GuestNice, _ = strconv.ParseUint(fields[10], 10, 64)
+
+	for i := 1; i < len(fields); i++ {
+		v, _ := strconv.ParseUint(fields[i], 10, 64)
+		switch i {
+		case 1:
+			s.User = v
+		case 2:
+			s.System = v
+		case 3:
+			s.Nice = v
+		case 4:
+			s.Idle = v
+		case 5:
+			s.IOWait = v
+		case 6:
+			s.IRQ = v
+		case 7:
+			s.SoftIRQ = v
+		case 8:
+			s.Steal = v
+		case 9:
+			s.Guest = v
+		case 10:
+			s.GuestNice = v
+		}
 	}
 	return &s
 }


### PR DESCRIPTION
In some environment like OpenVZ, cpu stat fields has only 9 cols:

```
# cat /proc/stat 
cpu  4611 1 2056 138437095 4398 0 0 0
cpu0 640 0 185 17302946 2177 0 0 0
cpu1 861 0 554 17304420 160 0 0 0
cpu2 356 0 91 17305495 123 0 0 0
cpu3 295 0 86 17305629 84 0 0 0
cpu4 367 0 211 17304693 720 0 0 0
cpu5 1384 0 386 17303986 281 0 0 0
cpu6 248 0 196 17305116 440 0 0 0
cpu7 455 0 345 17304807 409 0 0 0
intr 0
swap 0 0

ctxt 955681
btime 1426355694
processes 6499
procs_running 1
procs_blocked 0
```