### PR TITLE
fix sockstat expected values in test

### DIFF
--- a/linux/sockstat_test.go
+++ b/linux/sockstat_test.go
@@ -1,11 +1,25 @@
 package linux
 
-import "testing"
-import "reflect"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestSockStat(t *testing.T) {
-	var expected = SockStat{231, 27, 1, 23, 31, 3, 19, 17, 0, 0, 0, 0}
-
+	expected := SockStat{
+		SocketsUsed:  231,
+		TCPInUse:     27,
+		TCPOrphan:    1,
+		TCPTimeWait:  23,
+		TCPAllocated: 31,
+		TCPMemory:    3,
+		UDPInUse:     19,
+		UDPMemory:    17,
+		UDPLITEInUse: 0,
+		RAWInUse:     0,
+		FRAGInUse:    0,
+		FRAGMemory:   0,
+	}
 	sockStat, err := ReadSockStat("proc/sockstat")
 	if err != nil {
 		t.Fatal("sockstat read fail", err)


### PR DESCRIPTION
fix error:
sockstat_test.go:7:66: too few values in SockStat literal