### PR TITLE
Network socket's ref count can be hex

### DIFF
--- a/linux/net_unix.go
+++ b/linux/net_unix.go
@@ -41,7 +41,7 @@ func ReadNetUnixDomainSockets(fpath string) (*NetUnixDomainSockets, error) {
 		}
 
 		socket := NetUnixDomainSocket{}
-		if socket.RefCount, err = strconv.ParseUint(f[1], 10, 64); err != nil {
+		if socket.RefCount, err = strconv.ParseUint(f[1], 16, 64); err != nil {
 			return nil, errors.New("Cannot parse unix domain socket [invalid RefCount]: " + f[1])
 		}
 


### PR DESCRIPTION
Running latest arch and my refcounts are in hex not decimal.  No other values are failing to parse so unsure if they also can be hex and just aren't or are in decimal.