### PR TITLE
Snmp values may not exist

### DIFF
--- a/linux/snmp.go
+++ b/linux/snmp.go
@@ -124,7 +124,14 @@ func ReadSnmp(path string) (*Snmp, error) {
 		protocol := strings.Replace(strings.Fields(lines[i-1])[0], ":", "", -1)
 
 		for j, header := range headers {
-			statMap[protocol+header] = values[j]
+			var val string
+			if len(values) > j {
+				val = values[j]
+			} else {
+				val = "UNKNOWN"
+			}
+
+			statMap[protocol+header] = val
 		}
 	}
 


### PR DESCRIPTION
The index into values is not always valid which leads to a runtime panic.  For now I'm just inserting "UNKNOWN" as the value... if you have a better idea let me know.