### PR TITLE
Fixing the net/tcp parser so that we are no longer breaking on a rogue

### DIFF
--- a/linux/net_tcp.go
+++ b/linux/net_tcp.go
@@ -28,7 +28,7 @@ func ReadNetTCPSockets(path string, ip NetIPDecoder) (*NetTCPSockets, error) {
 		return nil, err
 	}
 
-	lines := strings.Split(string(b), "\n")
+	lines := strings.Split(strings.TrimRight(string(b), "\n "), "\n")
 
 	tcp := &NetTCPSockets{}
 


### PR DESCRIPTION
newline or whitespace.

This fixes some cases I saw where there was an extra \n on the /proc/net/tcp file and also fixes the test for the tcp6 file. All tests now pass.